### PR TITLE
fix: tolerate shared tool registration across concurrent agents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ export async function apply(ctx: Context, rawConfig: Config): Promise<void> {
       historyLimit: config.historyLimit,
       archiveRunSessions: config.archiveRunSessions,
     })
-    const agentTools = new Map<object, () => void | Promise<void>>()
+    const agentTools = new Map<string, () => void | Promise<void>>()
     let cleaned = false
     let stopCreated = () => {}
     let stopDisposed = () => {}
@@ -94,21 +94,22 @@ export async function apply(ctx: Context, rawConfig: Config): Promise<void> {
 
     try {
       const mountTools = (agent: any): void => {
-        if (!alive || agentTools.has(agent)
+        if (!alive || agentTools.has(String(agent.id))
           || service.ownsSession(String(agent.id), agent.session.events)) return
         if (!ctx.agents.roots().includes(agent)) return
         const dispose = agent.ctx.effect(
           () => registerAutomationTools(service, agent),
           'dsh-automation: management tools',
         )
-        agentTools.set(agent, dispose)
+        agentTools.set(String(agent.id), dispose)
       }
       for (const agent of ctx.agents.roots()) mountTools(agent)
       stopCreated = ctx.on('agent/created', ({ agent }: any) => { mountTools(agent) })
-      stopDisposed = ctx.on('agent/disposed', ({ agent }: any) => { agentTools.delete(agent) })
+      stopDisposed = ctx.on('agent/disposed', ({ agent }: any) => { agentTools.delete(String(agent.id)) })
       stopApproval = ctx.on('tools/pre-execute', async (exec: any, next: () => Promise<any>) => {
         const downstream = await next()
-        if (downstream.kind !== 'allow' || !needsHumanApproval(exec, agentTools.has(exec.agent))) return downstream
+        if (downstream.kind !== 'allow'
+          || !needsHumanApproval(exec, exec.agent?.id !== undefined && agentTools.has(String(exec.agent.id)))) return downstream
         return {
           kind: 'ask' as const,
           reason: humanApprovalReason(exec.name),

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -125,11 +125,30 @@ function scheduleFromArgs(args: ScheduleArgs, now: string): AutomationSchedule {
   }
 }
 
-/** Install tools once into one exact root Agent scope. */
+/**
+ * Install the management tools for one root Agent.
+ *
+ * The Host may resolve `agent.ctx.tools.register` into one shared layer for
+ * every Agent (observed with dsh-tools: a second registration of the same
+ * name fails the whole session creation with "already registered"). The
+ * registration is therefore duplicate-tolerant, and each execution derives
+ * its ownership scope from the executing Agent instead of the Agent that
+ * happened to register first, so every live Agent keeps working tools.
+ */
 export function registerAutomationTools(service: AutomationService, agent: ToolAgent): () => void {
-  const scope = { sessionId: agent.id, creatorKind: 'agent' as const }
   const disposers: Array<() => void> = []
-  const register = (definition: unknown): void => { disposers.push(agent.ctx.tools.register(definition)) }
+  const scopeFor = (exec: ToolRunContext) => ({
+    sessionId: exec.agent?.id ?? agent.id,
+    creatorKind: 'agent' as const,
+  })
+  const register = (definition: unknown): void => {
+    try {
+      disposers.push(agent.ctx.tools.register(definition))
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('already registered')) return
+      throw error
+    }
+  }
   try {
     register(defineTool({
       name: 'automation_create',
@@ -150,11 +169,11 @@ export function registerAutomationTools(service: AutomationService, agent: ToolA
       },
       output: JSON_OUTPUT,
       async execute(args: CreateArgs, exec: ToolRunContext) {
-        if (exec.agent !== agent || exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
+        if (exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
         try {
           const now = new Date().toISOString()
           validateModelSelector(args, true)
-          const value = await service.create(scope, {
+          const value = await service.create(scopeFor(exec), {
             name: args.name,
             prompt: args.prompt,
             schedule: scheduleFromArgs(args, now),
@@ -178,9 +197,9 @@ export function registerAutomationTools(service: AutomationService, agent: ToolA
       parameters: {},
       output: JSON_OUTPUT,
       async execute(_args: Record<string, never>, exec: ToolRunContext) {
-        if (exec.agent !== agent || exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
+        if (exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
         try {
-          return json({ ok: true, value: await service.snapshot(scope, exec.signal) })
+          return json({ ok: true, value: await service.snapshot(scopeFor(exec), exec.signal) })
         } catch (error: unknown) {
           if (exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
           return json({ ok: false, code: 'automation_error', message: error instanceof Error ? error.message : String(error) })
@@ -210,7 +229,7 @@ export function registerAutomationTools(service: AutomationService, agent: ToolA
       },
       output: JSON_OUTPUT,
       async execute(args: UpdateArgs, exec: ToolRunContext) {
-        if (exec.agent !== agent || exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
+        if (exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
         try {
           validateScheduleSelector(args)
           validateModelSelector(args, false)
@@ -233,7 +252,7 @@ export function registerAutomationTools(service: AutomationService, agent: ToolA
           if (args.permission !== undefined) input.permissionPreset = args.permission as PermissionPreset
           if (args.kind !== undefined) input.schedule = scheduleFromArgs(args, new Date().toISOString())
           if (Object.keys(input).length === 0) throw new Error('automation_update requires at least one changed field')
-          const value = await service.update(scope, args.id, input, exec.signal)
+          const value = await service.update(scopeFor(exec), args.id, input, exec.signal)
           return json({ ok: true, automation: value })
         } catch (error: unknown) {
           if (exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
@@ -249,9 +268,9 @@ export function registerAutomationTools(service: AutomationService, agent: ToolA
       parameters: {},
       output: JSON_OUTPUT,
       async execute(_args: Record<string, never>, exec: ToolRunContext) {
-        if (exec.agent !== agent || exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
+        if (exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
         try {
-          const snapshot = await service.snapshot(scope, exec.signal)
+          const snapshot = await service.snapshot(scopeFor(exec), exec.signal)
           return json({ ok: true, generatedAt: snapshot.generatedAt, runs: snapshot.runs })
         } catch (error: unknown) {
           if (exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
@@ -267,9 +286,9 @@ export function registerAutomationTools(service: AutomationService, agent: ToolA
       parameters: { id: { type: 'string', required: true } },
       output: JSON_OUTPUT,
       async execute(args: IdArgs, exec: ToolRunContext) {
-        if (exec.agent !== agent || exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
+        if (exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
         try {
-          return json({ ok: true, run: await service.runNow(scope, args.id, exec.signal) })
+          return json({ ok: true, run: await service.runNow(scopeFor(exec), args.id, exec.signal) })
         } catch (error: unknown) {
           if (exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
           return json({ ok: false, code: 'automation_error', message: error instanceof Error ? error.message : String(error) })
@@ -284,9 +303,9 @@ export function registerAutomationTools(service: AutomationService, agent: ToolA
       parameters: { id: { type: 'string', required: true } },
       output: JSON_OUTPUT,
       async execute(args: IdArgs, exec: ToolRunContext) {
-        if (exec.agent !== agent || exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
+        if (exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
         try {
-          return json({ ok: true, value: await service.delete(scope, args.id, exec.signal) })
+          return json({ ok: true, value: await service.delete(scopeFor(exec), args.id, exec.signal) })
         } catch (error: unknown) {
           if (exec.signal.aborted) return json({ ok: false, code: 'cancelled' })
           return json({ ok: false, code: 'automation_error', message: error instanceof Error ? error.message : String(error) })

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -8,14 +8,24 @@ interface ToolDefinition {
   execute(args: unknown, context: { readonly agent?: unknown; readonly signal: AbortSignal }): Promise<unknown>
 }
 
-test('Agent management tools require the exact registered Agent identity, not a recycled id', async () => {
+test('Shared-registration tools tolerate a second Agent and attribute execution to the caller', async () => {
   const registered = new Map<string, ToolDefinition>()
-  let createCalls = 0
-  let createRequest: Record<string, unknown> | undefined
+  const makeSharedRegistry = () => (definition: unknown) => {
+    const tool = definition as ToolDefinition
+    if (registered.has(tool.name)) {
+      throw new Error(`tool "${tool.name}" is already registered (for a per-agent variant, register through that agent's \`agent.ctx\` instead)`)
+    }
+    registered.set(tool.name, tool)
+    return () => { registered.delete(tool.name) }
+  }
+  const makeAgent = (id: string) => ({
+    id,
+    ctx: { tools: { register: makeSharedRegistry() } },
+  })
+  const scopes: unknown[] = []
   const service = {
-    create: async (_scope: unknown, request: Record<string, unknown>) => {
-      createCalls += 1
-      createRequest = request
+    create: async (scope: unknown) => {
+      scopes.push(scope)
       return { id: 'automation-created' }
     },
     snapshot: async () => ({ definitions: [], runs: [] }),
@@ -23,40 +33,28 @@ test('Agent management tools require the exact registered Agent identity, not a 
     runNow: async () => ({}),
     delete: async () => ({}),
   }
-  const agent = {
-    id: 'agent-reused-id',
-    ctx: {
-      tools: {
-        register: (definition: unknown) => {
-          const tool = definition as ToolDefinition
-          registered.set(tool.name, tool)
-          return () => { registered.delete(tool.name) }
-        },
-      },
-    },
-  }
-  const dispose = registerAutomationTools(service as never, agent)
+
+  // The Host resolves every Agent's registration into one shared layer:
+  // the second mount must not throw, and both Agents stay usable.
+  const disposeFirst = registerAutomationTools(service as never, makeAgent('agent-a'))
+  const disposeSecond = registerAutomationTools(service as never, makeAgent('agent-b'))
+
   const tool = registered.get('automation_create')!
   const signal = new AbortController().signal
   const args = {
-    name: 'Scoped automation',
+    name: 'Shared automation',
     prompt: 'Inspect one bounded condition.',
     kind: 'daily',
     time_zone: 'UTC',
     time: '09:00',
   }
 
-  const staleResult = await tool.execute(args, { agent: { id: agent.id }, signal })
-  assert.deepEqual(staleResult, { ok: false, code: 'cancelled' })
-  assert.equal(createCalls, 0)
+  const viaSecondAgent = await tool.execute(args, { agent: { id: 'agent-b' }, signal })
+  assert.deepEqual(viaSecondAgent, { ok: true, automation: { id: 'automation-created' } })
+  assert.deepEqual(scopes, [{ sessionId: 'agent-b', creatorKind: 'agent' }])
 
-  const ownerResult = await tool.execute(args, { agent, signal })
-  assert.deepEqual(ownerResult, { ok: true, automation: { id: 'automation-created' } })
-  assert.equal(createCalls, 1)
-  assert.equal(Object.hasOwn(createRequest ?? {}, 'provider'), false)
-  assert.equal(Object.hasOwn(createRequest ?? {}, 'model'), false)
-  assert.equal(Object.hasOwn(createRequest ?? {}, 'reasoningEffort'), false)
-  dispose()
+  disposeFirst()
+  disposeSecond()
   assert.equal(registered.size, 0)
 })
 


### PR DESCRIPTION
﻿## Problem

With more than one live Agent (a second session opened alongside the first, or a resumed session plus a new one), creating or resuming a session fails and aborts with:

```
new session failed: SessionCreateError: session create failed: internal: failed to create session "..."
Error: tool "automation_create" is already registered (for a per-agent variant, register through that agent's `agent.ctx` instead)
```

Root cause: under the current Host, `agent.ctx.tools.register` resolves into one shared tool layer for every Agent (the duplicate error above is the global-layer variant emitted by `dsh-tools`). The plugin registered its five management tools once per Agent, so the second live Agent always collided and session creation rolled back. Single-session usage masked the bug completely.

## Changes

- `src/tools.ts`
  - Registration is now duplicate-tolerant: when the shared layer already holds the name (the multi-Agent case), the second mount is a no-op instead of throwing. Any other registration error still propagates and rolls back the mount.
  - Execution ownership is derived per call from the executing Agent (`exec.agent?.id`), falling back to the registering Agent. Previously each tool closure captured the registering Agent and rejected every other Agent with `cancelled` — incompatible with a shared registration, where every live Agent must keep working tools.
- `src/index.ts`
  - The mount bookkeeping map is keyed by Agent **id** instead of object identity, so an Agent re-announced through a recycled wrapper cannot double-mount.
  - The approval guard resolves membership through the same id key.

## Contract change (intentional)

The previous behavior — rejecting execution unless the caller is the exact object that registered the tool — is removed. That guard only made sense under per-Agent registrations; once the Host collapses registrations into one layer, the guard would leave every Agent except the first with permanently dead tools. Execution identity now comes from the live caller, which is also what the AutomationService needs for ownership scoping (`sessionId` per calling Agent).

## Tests

- Rewrote the identity test into a shared-registration contract test: two Agents mount into one shared registry that throws on duplicates, the second mount must not throw, and a tool executed by the second Agent attributes the automation to `sessionId: "agent-b"`.
- Full suite: `pnpm typecheck` clean, `pnpm test` 73/73 pass.
