### PR TITLE
fix: explain automation rejection when approval prompts are disabled

### DIFF
--- a/docs/APPROVAL-DIAGNOSTICS.zh-CN.md
+++ b/docs/APPROVAL-DIAGNOSTICS.zh-CN.md
@@ -1,0 +1,21 @@
+# Issue #23：未弹窗却报告用户拒绝
+
+## 已确认的机制
+
+截图中的 automation_create 在约 3 ms 内返回 the user rejected tool。仅凭截图不能确认远端会话策略。
+
+当前 Desktop app.asar 的 dsh-user-approval@0.1.5-rc.1 在 effectivePolicy(session) 为 never 时，直接返回 rejected，不调用 approval/request 响应端。dsh-tools 将 rejected 一律翻译为 the user rejected tool。在隔离环境中提取并调用这两个真实方法，复现 prompts=0，同时得到截图中的错误文本；未连接真实 Agent、写入会话或改变策略。
+
+## 插件修复
+
+插件自身要求人工审批的操作，在下游允许后读取宿主提供的 effectivePolicy(session)。若为 never，明确报告策略自动阻止，告知用户改用 ask 后重试，或在自动化页面手动管理；不再声称用户点击拒绝。策略读取失败时明确诊断并阻止执行。
+
+ask 及不提供策略读取接口的旧宿主仍使用原有 ask 流程。其他拦截器的拒绝/审批结果、取消、非管理 Agent、只读查询和纯暂停操作保持原状。没有自动放行，也没有修改任何审批策略。
+
+## 验证与限制
+
+157 项测试、类型检查及 Host / Client 构建通过。新增 4 项测试覆盖 never、ask、旧接口、前置拒绝、取消、纯暂停及读取失败。
+
+这修复的是策略禁用导致的误导反馈，不是强制弹出审批。若报告者实际使用 ask，仍需其审批日志核对响应端是否返回 rejected；现有截图不足以确定这一分支。PR #24 的 Agent 初始化适配与此问题独立。
+
+本修复不包含 RPC 注册兼容改动或 PR #24 的 Agent 初始化适配；不改变审批策略，不操作真实自动化。需重新加载宿主后应用构建产物。

--- a/lib/index.js
+++ b/lib/index.js
@@ -23024,6 +23024,20 @@ function needsHumanApproval(exec, isMountedAgent) {
 function humanApprovalReason(toolName) {
   return toolName === "automation_delete" ? "This action permanently deletes an automation definition. Its run history is retained, but the schedule cannot be restored automatically." : "This action creates or expands unattended future work. Review its prompt, schedule, workspace, and permission boundary.";
 }
+function automationApprovalDecision(exec, isMountedAgent, downstream, readPolicy) {
+  if (downstream.kind !== "allow" || !needsHumanApproval(exec, isMountedAgent)) return downstream;
+  let policy;
+  try {
+    policy = readPolicy();
+  } catch {
+    return { kind: "deny", reason: "Cannot read this session's approval policy. No automation was changed. Check the Host approval service or manage the task in the Automations view." };
+  }
+  if (policy === "never") return {
+    kind: "deny",
+    reason: `This session's approval policy is "never": approval prompts are disabled and this automation action is blocked automatically, not rejected by the user. Ask the user to switch the session approval policy to "ask" and retry, or create/manage the task manually in the Automations view. Do not retry automatically or change the approval policy yourself.`
+  };
+  return { kind: "ask", reason: humanApprovalReason(exec.name) };
+}
 async function apply(ctx, rawConfig) {
   const config2 = rawConfig;
   await ctx.effect(async () => {
@@ -23115,11 +23129,15 @@ async function apply(ctx, rawConfig) {
       });
       stopApproval = ctx.on("tools/pre-execute", async (exec, next) => {
         const downstream = await next();
-        if (downstream.kind !== "allow" || !needsHumanApproval(exec, exec.agent?.id !== void 0 && agentTools.has(String(exec.agent.id)))) return downstream;
-        return {
-          kind: "ask",
-          reason: humanApprovalReason(exec.name)
-        };
+        return automationApprovalDecision(
+          exec,
+          exec.agent?.id !== void 0 && agentTools.has(String(exec.agent.id)),
+          downstream,
+          () => {
+            const approval = ctx.get("approval");
+            return approval?.effectivePolicy?.(exec.agent.session);
+          }
+        );
       });
       removeRpc = registerAutomationRpc(ctx, service);
       const loader = ctx.get("loader");
@@ -23141,6 +23159,7 @@ async function apply(ctx, rawConfig) {
 export {
   Config,
   apply,
+  automationApprovalDecision,
   automationDomainSpec,
   humanApprovalReason,
   inject,

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -20,6 +20,14 @@ export declare function needsHumanApproval(exec: {
     readonly signal: AbortSignal;
 }, isMountedAgent: boolean): boolean;
 export declare function humanApprovalReason(toolName: string): string;
+/** Preserve all prior gates and explain deterministic policy rejection before the Host mislabels it. */
+export declare function automationApprovalDecision(exec: Parameters<typeof needsHumanApproval>[0], isMountedAgent: boolean, downstream: {
+    readonly kind: string;
+    readonly reason?: string;
+}, readPolicy: () => unknown): {
+    readonly kind: string;
+    readonly reason?: string;
+};
 /** Mount one host-wide authority and agent-scoped management tools. */
 export declare function apply(ctx: Context, rawConfig: Config): Promise<void>;
 export type * from './types.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,25 @@ export function humanApprovalReason(toolName: string): string {
     : 'This action creates or expands unattended future work. Review its prompt, schedule, workspace, and permission boundary.'
 }
 
+/** Preserve all prior gates and explain deterministic policy rejection before the Host mislabels it. */
+export function automationApprovalDecision(
+  exec: Parameters<typeof needsHumanApproval>[0],
+  isMountedAgent: boolean,
+  downstream: { readonly kind: string; readonly reason?: string },
+  readPolicy: () => unknown,
+): { readonly kind: string; readonly reason?: string } {
+  if (downstream.kind !== 'allow' || !needsHumanApproval(exec, isMountedAgent)) return downstream
+  let policy: unknown
+  try { policy = readPolicy() } catch {
+    return { kind: 'deny', reason: 'Cannot read this session\'s approval policy. No automation was changed. Check the Host approval service or manage the task in the Automations view.' }
+  }
+  if (policy === 'never') return {
+    kind: 'deny',
+    reason: 'This session\'s approval policy is "never": approval prompts are disabled and this automation action is blocked automatically, not rejected by the user. Ask the user to switch the session approval policy to "ask" and retry, or create/manage the task manually in the Automations view. Do not retry automatically or change the approval policy yourself.',
+  }
+  return { kind: 'ask', reason: humanApprovalReason(exec.name) }
+}
+
 /** Mount one host-wide authority and agent-scoped management tools. */
 export async function apply(ctx: Context, rawConfig: Config): Promise<void> {
   const config = rawConfig as Required<Config>
@@ -152,12 +171,15 @@ export async function apply(ctx: Context, rawConfig: Config): Promise<void> {
       stopDisposed = ctx.on('agent/disposed', ({ agent }: any) => { agentTools.delete(String(agent.id)) })
       stopApproval = ctx.on('tools/pre-execute', async (exec: any, next: () => Promise<any>) => {
         const downstream = await next()
-        if (downstream.kind !== 'allow'
-          || !needsHumanApproval(exec, exec.agent?.id !== undefined && agentTools.has(String(exec.agent.id)))) return downstream
-        return {
-          kind: 'ask' as const,
-          reason: humanApprovalReason(exec.name),
-        }
+        return automationApprovalDecision(
+          exec,
+          exec.agent?.id !== undefined && agentTools.has(String(exec.agent.id)),
+          downstream,
+          () => {
+            const approval = ctx.get('approval') as { effectivePolicy?: (session: unknown) => unknown } | undefined
+            return approval?.effectivePolicy?.(exec.agent.session)
+          },
+        )
       })
       removeRpc = registerAutomationRpc(ctx, service)
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { humanApprovalReason, needsHumanApproval } from '../src/index.ts'
+import { automationApprovalDecision, humanApprovalReason, needsHumanApproval } from '../src/index.ts'
 
 test('approval is scoped to mounted Agents, includes delete, and ignores cancelled calls', () => {
   const signal = new AbortController().signal
@@ -17,4 +17,42 @@ test('approval is scoped to mounted Agents, includes delete, and ignores cancell
   cancelled.abort()
   assert.equal(needsHumanApproval({ name: 'automation_run_now', signal: cancelled.signal }, true), false)
   assert.match(humanApprovalReason('automation_delete'), /permanently deletes/)
+})
+
+
+test('never policy reports automatic rejection without impersonating a human decision', () => {
+  const exec = { name: 'automation_create', signal: new AbortController().signal }
+  const decision = automationApprovalDecision(exec, true, { kind: 'allow' }, () => 'never')
+  assert.equal(decision.kind, 'deny')
+  assert.match(decision.reason!, /approval prompts are disabled/)
+  assert.match(decision.reason!, /not rejected by the user/)
+  assert.match(decision.reason!, /"ask"/)
+  assert.match(decision.reason!, /Automations view/)
+})
+
+test('interactive and older hosts retain the normal approval path, never automatic allow', () => {
+  for (const policy of ['ask', undefined]) {
+    const decision = automationApprovalDecision({ name: 'automation_create', signal: new AbortController().signal }, true, { kind: 'allow' }, () => policy)
+    assert.equal(decision.kind, 'ask')
+  }
+})
+
+test('prior rejection, cancellation, unmounted agents and pure pause keep their decisions', () => {
+  const signal = new AbortController().signal
+  const unread = () => { throw new Error('policy must not be read') }
+  for (const kind of ['deny', 'ask']) {
+    const prior = { kind, reason: 'existing gate' }
+    assert.equal(automationApprovalDecision({ name: 'automation_create', signal }, true, prior, unread), prior)
+  }
+  const allow = { kind: 'allow' }
+  assert.equal(automationApprovalDecision({ name: 'automation_create', signal: AbortSignal.abort() }, true, allow, unread), allow)
+  assert.equal(automationApprovalDecision({ name: 'automation_create', signal }, false, allow, unread), allow)
+  assert.equal(automationApprovalDecision({ name: 'automation_update', arguments: { id: 'a', status: 'paused' }, signal }, true, allow, unread), allow)
+  assert.equal(automationApprovalDecision({ name: 'automation_list', signal }, true, allow, unread), allow)
+})
+
+test('policy read failure fails closed with a diagnostic instead of silently allowing', () => {
+  const result = automationApprovalDecision({ name: 'automation_create', signal: new AbortController().signal }, true, { kind: 'allow' }, () => { throw new Error('Host unavailable') })
+  assert.equal(result.kind, 'deny')
+  assert.match(result.reason!, /Cannot read/)
 })


### PR DESCRIPTION
When an Agent calls an automation management tool under approval policy `never`, the Host rejects the approval request without showing a prompt, then reports `the user rejected tool "automation_create"`. This makes a policy denial look like a human decision.

This change reads the Host's effective session policy before this plugin emits its own `ask` decision. Under `never`, it returns an explicit policy-denial explanation and asks the user to switch to `ask` or manage the automation manually in the Automations view. It never changes the policy or automatically allows an action. Interactive/older Hosts retain the existing approval path; prior gates, cancellation, read-only tools, and pure pause updates keep their behavior. Policy-read errors fail closed with a diagnostic.

Related to #23. This does not claim to explain every no-prompt rejection: the reporter's session policy is not yet confirmed. An `ask`-policy rejection still needs investigation of the Host approval answerer. Please do not treat this as an automatic close of #23.

Validation:
- Isolated replay of the actual Desktop approval `decide` and tool `serviceAsk` methods reproduced zero prompt calls with the exact reported rejection under `never`.
- `pnpm check` passes on a clean worktree based on current upstream main: 157 tests, typecheck, and Host/Client build. Four new tests cover policy handling and preservation of existing gates.
- `git diff --check` passes. Host bundle and declarations included.
- No live automation was run and no user session policy was changed.

This PR excludes the local RPC compatibility changes and PR #24's Agent setup adaptation. Details: `docs/APPROVAL-DIAGNOSTICS.zh-CN.md`.